### PR TITLE
Feature: EinopsToAndFrom: Allow '...' in expression

### DIFF
--- a/einops_exts/torch.py
+++ b/einops_exts/torch.py
@@ -10,10 +10,18 @@ class EinopsToAndFrom(nn.Module):
         self.to_einops = to_einops
         self.fn = fn
 
+        if "..." in from_einops:
+            before, after = [part.strip().split(" ") for part in from_einops.split("...")]
+            self.reconstitute_keys = tuple(zip(before, range(len(before)))) + tuple(zip(after, range(-len(after), 0)))
+        else:
+            split = from_einops.strip().split(" ")
+            self.reconstitute_keys = tuple(zip(split, range(len(split))))
+
+
     def forward(self, x, **kwargs):
         shape = x.shape
-        reconstitute_kwargs = dict(tuple(zip(self.from_einops.split(' '), shape)))
-        x = rearrange(x, f'{self.from_einops} -> {self.to_einops}')
+        reconstitute_kwargs = {key: shape[position] for key, position in self.reconstitute_keys}
+        x = rearrange(x, f"{self.from_einops} -> {self.to_einops}")
         x = self.fn(x, **kwargs)
-        x = rearrange(x, f'{self.to_einops} -> {self.from_einops}', **reconstitute_kwargs)
+        x = rearrange(x, f"{self.to_einops} -> {self.from_einops}", **reconstitute_kwargs)
         return x

--- a/einops_exts/torch.py
+++ b/einops_exts/torch.py
@@ -10,18 +10,18 @@ class EinopsToAndFrom(nn.Module):
         self.to_einops = to_einops
         self.fn = fn
 
-        if "..." in from_einops:
-            before, after = [part.strip().split(" ") for part in from_einops.split("...")]
+        if '...' in from_einops:
+            before, after = [part.strip().split() for part in from_einops.split('...')]
             self.reconstitute_keys = tuple(zip(before, range(len(before)))) + tuple(zip(after, range(-len(after), 0)))
         else:
-            split = from_einops.strip().split(" ")
+            split = from_einops.strip().split()
             self.reconstitute_keys = tuple(zip(split, range(len(split))))
 
 
     def forward(self, x, **kwargs):
         shape = x.shape
         reconstitute_kwargs = {key: shape[position] for key, position in self.reconstitute_keys}
-        x = rearrange(x, f"{self.from_einops} -> {self.to_einops}")
+        x = rearrange(x, f'{self.from_einops} -> {self.to_einops}')
         x = self.fn(x, **kwargs)
-        x = rearrange(x, f"{self.to_einops} -> {self.from_einops}", **reconstitute_kwargs)
+        x = rearrange(x, f'{self.to_einops} -> {self.from_einops}', **reconstitute_kwargs)
         return x


### PR DESCRIPTION
In the EinopsToAndFrom layer, ellipsis used to (incorrectly) capture the  shape of the first axis captured by the ellipsis. This also caused missalignment for all the other captures shapes.

 We now just do not capture the size of ellipsis and keep it in the undo-stage as an ellipsis.

This also allows one to use '...' for an axis that changes its size in the function :)

The actual implementation of the new __init__ might not be the cleanest, but works.